### PR TITLE
fix(lanyard): tipa timestamps em activities

### DIFF
--- a/src/hooks/useLanyard.ts
+++ b/src/hooks/useLanyard.ts
@@ -33,6 +33,10 @@ export interface LanyardData {
     name: string;
     state?: string;
     details?: string;
+    timestamps?: {
+      start?: number;
+      end?: number;
+    };
     assets?: {
       large_image?: string;
       small_image?: string;


### PR DESCRIPTION
## Resumo

Corrige a tipagem do payload do Lanyard para incluir `timestamps` (opcional) em `activities`, removendo a falha de build do Next.js/TypeScript no componente `DiscordStatus`.

## O que foi alterado

- Atualizado `src/hooks/useLanyard.ts` para adicionar `timestamps?: { start?: number; end?: number }` no tipo de `activities`.

## Motivação

O `DiscordStatus` acessa `activity.timestamps`, mas o contrato tipado do hook não contemplava essa propriedade, causando erro de compilação em `next build`.

## Como validar

- `npx tsc --noEmit`
- `npm run build`

## Riscos e impactos

- Risco baixo: mudança apenas de tipos, mantendo `timestamps` como opcional.
- Observação: `npm run lint` falha no repo por problemas pré-existentes e não relacionados a esta PR.

## Evidências

- Build local sem erro de TypeScript em `DiscordStatus` após o ajuste de tipos.

## Checklist

- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #5