### PR TITLE
feat(ui): Current_Focus dinâmico com Gemini

### DIFF
--- a/src/actions/generateStatus.ts
+++ b/src/actions/generateStatus.ts
@@ -1,0 +1,139 @@
+"use server";
+
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { unstable_cache } from "next/cache";
+
+import { getGithubEvents } from "@/lib/github";
+
+type TimePeriod = "madrugada" | "manhã" | "tarde" | "noite";
+
+interface LanyardUserResponse {
+  success: boolean;
+  data: {
+    listening_to_spotify: boolean;
+    spotify: {
+      song: string;
+      artist: string;
+    } | null;
+  };
+}
+
+function clampSnippet(input: string, maxLen: number): string {
+  const normalized = input.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLen) return normalized;
+  return `${normalized.slice(0, maxLen - 1)}…`;
+}
+
+function getLocalHour(timeZone: string): number {
+  const hourText = new Intl.DateTimeFormat("pt-BR", {
+    hour: "2-digit",
+    hour12: false,
+    timeZone,
+  }).format(new Date());
+
+  const hour = Number(hourText);
+  return Number.isFinite(hour) ? hour : new Date().getHours();
+}
+
+function getTimePeriod(hour: number): TimePeriod {
+  if (hour < 6) return "madrugada";
+  if (hour < 12) return "manhã";
+  if (hour < 18) return "tarde";
+  return "noite";
+}
+
+async function fetchSpotifyContextFromLanyard(): Promise<
+  | { listeningToSpotify: true; song: string; artist: string }
+  | { listeningToSpotify: false }
+> {
+  const discordId = process.env.NEXT_PUBLIC_DISCORD_USER_ID;
+  if (!discordId) return { listeningToSpotify: false };
+
+  const response = await fetch(`https://api.lanyard.rest/v1/users/${discordId}`, {
+    next: { revalidate: 60 },
+  });
+
+  if (!response.ok) return { listeningToSpotify: false };
+
+  const json: unknown = await response.json();
+  if (!json || typeof json !== "object") return { listeningToSpotify: false };
+
+  const payload = json as Partial<LanyardUserResponse>;
+  if (!payload.success || !payload.data) return { listeningToSpotify: false };
+
+  if (!payload.data.listening_to_spotify || !payload.data.spotify) {
+    return { listeningToSpotify: false };
+  }
+
+  const { song, artist } = payload.data.spotify;
+  if (!song || !artist) return { listeningToSpotify: false };
+
+  return {
+    listeningToSpotify: true,
+    song: clampSnippet(song, 60),
+    artist: clampSnippet(artist, 60),
+  };
+}
+
+async function getLastCommitMessage(): Promise<string | null> {
+  const events = await getGithubEvents();
+  const lastPush = events.find((ev) => ev.type === "PushEvent");
+  if (!lastPush?.message) return null;
+
+  const msg = clampSnippet(lastPush.message, 80);
+  return msg.length > 0 ? msg : null;
+}
+
+async function generateLivingStatusUncached(): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) return "System Idle...";
+
+  const [lastCommitMessage, spotifyContext] = await Promise.all([
+    getLastCommitMessage(),
+    fetchSpotifyContextFromLanyard(),
+  ]);
+
+  const hour = getLocalHour("America/Cuiaba");
+  const timePeriod = getTimePeriod(hour);
+
+  const commitLine = lastCommitMessage
+    ? `Último commit: "${lastCommitMessage}".`
+    : "Sem commit público recente detectado.";
+
+  const spotifyLine =
+    spotifyContext.listeningToSpotify
+      ? `Spotify: ouvindo "${spotifyContext.song}" — ${spotifyContext.artist}.`
+      : "Spotify: sem música no momento.";
+
+  const prompt = [
+    "Você é um bardo cyberpunk que narra o foco atual de um desenvolvedor.",
+    "Gere exatamente 1 frase curta (máximo 120 caracteres), em PT-BR.",
+    "Sem emojis. Sem aspas na resposta. Sem quebras de linha.",
+    `Período do dia: ${timePeriod}.`,
+    commitLine,
+    spotifyLine,
+    "Saída:",
+  ].join("\n");
+
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+
+  const result = await model.generateContent(prompt);
+  const response = await result.response;
+  const text = clampSnippet(response.text(), 140);
+
+  return text.length > 0 ? text : "System Idle...";
+}
+
+export const generateLivingStatus = unstable_cache(
+  async (): Promise<string> => {
+    try {
+      return await generateLivingStatusUncached();
+    } catch {
+      return "System Idle...";
+    }
+  },
+  ["living-status-v1"],
+  { revalidate: 600 }
+);
+

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+import { generateLivingStatus } from "@/actions/generateStatus";
+
+export async function GET() {
+  const status = await generateLivingStatus();
+  return NextResponse.json({ status });
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -218,3 +218,32 @@ body::before {
   color: #00ff00 !important;
   text-shadow: 0 0 5px #00ff00;
 }
+
+/* ==========================================================================
+   6. Typewriter (Current Focus)
+   ========================================================================== */
+@keyframes typewriter-reveal {
+  from {
+    max-width: 0;
+  }
+  to {
+    max-width: 60ch;
+  }
+}
+
+@keyframes typewriter-caret {
+  50% {
+    border-color: transparent;
+  }
+}
+
+.typewriter {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 0;
+  border-right: 1px solid rgba(234, 179, 8, 0.65);
+  animation:
+    typewriter-reveal 2.6s steps(44, end) 0.15s forwards,
+    typewriter-caret 900ms step-end infinite;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 // import Link from "next/link"; <--- REMOVIDO (Substituído pelo TrackedLink onde necessário)
 import { Youtube, Activity } from "lucide-react";
 
@@ -17,6 +16,7 @@ import HeroAvatar from "@/components/HeroAvatar";
 import { NexusControlPanel } from "@/components/NexusControlPanel";
 import { GithubWidget } from "@/components/GithubWidget"; 
 import { DiscordStatus } from "@/components/DiscordStatus"; 
+import { CurrentFocusWidget } from "@/components/CurrentFocusWidget";
 
 // --- TELEMETRIA ---
 import { TrackedLink } from "@/components/TrackedLink"; // <--- NOVO IMPORT
@@ -96,21 +96,13 @@ export default function Home() {
            <NexusControlPanel 
               githubSlot={<GithubWidget />} 
               discordSlot={
-                <div className="h-full flex flex-col gap-4">
-                  <DiscordStatus />
-                  <div className="flex-1 p-4 bg-zinc-900/40 border border-yellow-500/20 rounded-xl hover:border-yellow-500/50 transition-colors flex flex-col justify-center">
-                      <div className="flex items-center gap-2 mb-2 text-yellow-500 text-xs font-mono font-bold uppercase">
-                         <span className="w-2 h-2 bg-yellow-500 rounded-full animate-ping" />
-                         Current_Focus
-                      </div>
-                      <p className="text-sm text-zinc-300">
-                         Otimizando algoritmos de <strong>OCR</strong> para a <strong>Nexus Eleva</strong>.
-                      </p>
+                  <div className="h-full flex flex-col gap-4">
+                    <DiscordStatus />
+                   <CurrentFocusWidget />
                   </div>
-                </div>
-              }
-           />
-        </section>
+               }
+            />
+         </section>
 
 
         {/* TECH STACKS */}

--- a/src/components/CurrentFocusWidget.tsx
+++ b/src/components/CurrentFocusWidget.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import useSWR from "swr";
+
+interface StatusResponse {
+  status: string;
+}
+
+async function fetcher(url: string): Promise<StatusResponse> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Status request failed: ${res.status}`);
+  }
+  const data: unknown = await res.json();
+  if (!data || typeof data !== "object" || !("status" in data)) {
+    throw new Error("Invalid status payload");
+  }
+  const status = (data as { status: unknown }).status;
+  if (typeof status !== "string") {
+    throw new Error("Invalid status type");
+  }
+  return { status };
+}
+
+export function CurrentFocusWidget() {
+  const { data, isLoading, error } = useSWR<StatusResponse>("/api/status", fetcher, {
+    revalidateOnFocus: false,
+    dedupingInterval: 5 * 60 * 1000,
+  });
+
+  const text = error
+    ? "System Idle..."
+    : isLoading
+      ? "Sincronizando sinais..."
+      : data?.status ?? "System Idle...";
+
+  return (
+    <div className="flex-1 p-4 bg-zinc-900/40 border border-yellow-500/20 rounded-xl hover:border-yellow-500/50 transition-colors flex flex-col justify-center">
+      <div className="flex items-center gap-2 mb-2 text-yellow-500 text-xs font-mono font-bold uppercase">
+        <span className="w-2 h-2 bg-yellow-500 rounded-full animate-ping" />
+        Current_Focus
+      </div>
+      <p className="text-sm text-zinc-300 font-mono">
+        <span className="typewriter">{text}</span>
+      </p>
+    </div>
+  );
+}
+


### PR DESCRIPTION
﻿## Resumo
Implementa o "Living Portfolio" no bloco Current_Focus, gerando uma frase curta via Gemini a partir de sinais do GitHub (?ltimo commit p?blico) e do Spotify via Lanyard, com cache para reduzir custo e evitar chamadas excessivas.

## O que foi alterado
- Criado `src/actions/generateStatus.ts` (server-only) para montar contexto, chamar Gemini e aplicar cache (10 min).
- Adicionado endpoint `src/app/api/status/route.ts` para expor o texto gerado ao client sem vazar API Key.
- Atualizado `src/app/page.tsx` para substituir o texto mockado por um widget din?mico.
- Criado `src/components/CurrentFocusWidget.tsx` para buscar `/api/status` via SWR e renderizar com efeito typewriter.
- Adicionado estilo global `.typewriter` em `src/app/globals.css`.

## Motiva??o
A issue #3 pede que o Current_Focus deixe de ser est?tico e passe a refletir a atividade atual, com gera??o de texto por IA e prote??o de chave (server-side) + cache para estabilidade em deploy na Vercel.

## Como validar
- `npx tsc --noEmit`
- `npm run build`
- Opcional (runtime): abrir a home, expandir o Nexus Control Panel e verificar que o bloco Current_Focus exibe uma frase din?mica (ou fallback).

## Riscos e impactos
- Risco baixo: o widget possui fallback "System Idle..." quando faltar `GEMINI_API_KEY`, `NEXT_PUBLIC_DISCORD_USER_ID` ou houver falha externa.
- Cache: atualiza??o do texto ? intencionalmente limitada (10 min) para reduzir uso de API.
- Observa??o: `npm run lint` falha no reposit?rio por erros pr?-existentes (n?o introduzidos nesta PR).

## Evid?ncias
- Build local passou (`npm run build`) e o novo endpoint `/api/status` aparece nas rotas geradas.

## Checklist
- [ ] Altera??o limitada ao objetivo da PR
- [ ] Sem mudan?as desconexas
- [ ] Impactos principais descritos
- [ ] Valida??o documentada
- [ ] Riscos identificados

Closes #3
