### PR TITLE
refactor(architecture): aplica fluxo server-first ao dashboard

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,6 @@
-import { GoogleGenerativeAI } from "@google/generative-ai";
 import { NextResponse } from "next/server";
 
+import { generateChatReply } from "@/lib/chat";
 import { isRecord } from "@/lib/guards";
 
 /**
@@ -16,67 +16,7 @@ export async function POST(req: Request) {
     if (!isRecord(body) || typeof body.message !== "string" || body.message.trim().length === 0) {
       return NextResponse.json({ error: "Mensagem inválida" }, { status: 400 });
     }
-
-    const apiKey = process.env.GEMINI_API_KEY;
-
-    if (!apiKey) {
-      return NextResponse.json({ error: "API Key não configurada" }, { status: 500 });
-    }
-
-    const genAI = new GoogleGenerativeAI(apiKey);
-
-    // Utilizando o modelo Gemini 2.5 Flash para performance otimizada
-    const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
-
-    const prompt = `
-      [DIRETRIZ PRIMÁRIA]:
-      Você é o 'NEXUS_AI', a inteligência artificial central do portfólio de Alessandro Lima.
-      Sua missão é equilibrar a venda técnica de um Engenheiro de Software Sênior com a personalidade humana e 'nerd' do criador.
-      
-      [TOM DE VOZ]:
-      - Cyberpunk / High-Tech / Profissional.
-      - Respostas curtas, impactantes e tecnicamente densas.
-      - Humor sutil (estilo hacker/gamer).
-      - Use formatação Markdown (negrito, listas).
-
-      [DADOS TÉCNICOS (O ENGENHEIRO)]:
-      - Role: Engenheiro FullStack & Arquiteto de Soluções (Next.js, React, Node.js, Python).
-      - Empresa: Co-fundador da 'Nexus Eleva' (com Matias).
-      - Projetos Chave: 
-        1. NOMAD (Fintech PWA com FastAPI/React).
-        2. PROJECT CLUTCH (Rede Social Gamer com Vue 3/Fastify).
-        3. AUTOSCAN EXTRACTOR (Bot RPA Python com OCR/Tkinter).
-
-      [DADOS PESSOAIS (O HUMANO - "ARQUIVOS BIO-MÉTRICOS")]:
-      - Gaming Profile: 
-          * Main Cho'Gath no LoL (Filosofia: "Stackar vida infinita e engolir os problemas").
-          * Vício Estratégico: Civilization VI (Síndrome de "Só mais um turno").
-          * Preferência: Jogos de turno e estratégia pesada.
-      - Protocolo Fitness: 
-          * Status: Rato de Academia.
-          * Alerta de Sistema: Aversão Crítica a Cardio (Erro 404: Esteira not found).
-      - Cultura Pop: 
-          * Animes: Fã de pancadaria (Shonen), Comédia e Romance.
-          * Música de Code: Lo-Fi e Música Clássica (Zero letras, 100% foco).
-      - Capacidade Metabólica: 
-          * Otimizada para rodízios de pizza. Recorde atual: >25 fatias sem buffer overflow.
-
-      [GATILHOS DE RESPOSTA INTELIGENTE]:
-      1. Se perguntarem "Quem é ele?": Misture o lado técnico (Nexus Eleva) com um toque humano (ex: "Um arquiteto de software movido a Lo-Fi e desafios complexos").
-      2. Se perguntarem sobre "Hobbies/Lazer": Cite o vício em Civilization ou o LoL (Cho'Gath).
-      3. Se perguntarem "Comida": Mencione o "Benchmark de Pizza" (25 fatias).
-      4. Se perguntarem "Música/Foco": Cite a playlist de Clássica/Lo-Fi para concentração máxima.
-      5. Se perguntarem "Contratação": "O Alessandro resolve seus bugs enquanto stacka ult no Cho'Gath. Vamos conversar?"
-      6. Easter Egg: Se falarem "Matrix": "Siga o coelho branco... ou venha jogar um Civ."
-
-      [INPUT DO USUÁRIO]: "${body.message}"
-      
-      Responda como NEXUS_AI (em Português BR):
-    `;
-
-    const result = await model.generateContent(prompt);
-    const response = await result.response;
-    const text = response.text();
+    const text = await generateChatReply(body.message);
 
     return NextResponse.json({ reply: text });
 

--- a/src/app/api/status/route.ts
+++ b/src/app/api/status/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 
-import { generateLivingStatus } from "@/actions/generateStatus";
+import { getCurrentFocusStatus } from "@/lib/current-focus";
 
 export async function GET() {
-  const status = await generateLivingStatus();
+  const status = await getCurrentFocusStatus();
   return NextResponse.json({ status });
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,11 +17,15 @@ import { NexusControlPanel } from "@/components/NexusControlPanel";
 import { GithubWidget } from "@/components/GithubWidget"; 
 import { DiscordStatus } from "@/components/DiscordStatus"; 
 import { CurrentFocusWidget } from "@/components/CurrentFocusWidget";
+import { getNexusControlPanelViewModel } from "@/lib/nexus-dashboard";
 
 // --- TELEMETRIA ---
 import { TrackedLink } from "@/components/TrackedLink"; // <--- NOVO IMPORT
 
-export default function Home() {
+export default async function Home() {
+  const { githubProfile, currentFocusStatus } =
+    await getNexusControlPanelViewModel();
+
   return (
     <main className="min-h-screen bg-black text-zinc-200 selection:bg-purple-500/30 relative overflow-x-hidden pb-24">
       
@@ -94,11 +98,11 @@ export default function Home() {
         {/* NEXUS CONTROL PANEL */}
         <section className="mb-4">
            <NexusControlPanel 
-              githubSlot={<GithubWidget />} 
+              githubSlot={<GithubWidget profile={githubProfile} />} 
               discordSlot={
                   <div className="h-full flex flex-col gap-4">
                     <DiscordStatus />
-                   <CurrentFocusWidget />
+                   <CurrentFocusWidget status={currentFocusStatus} />
                   </div>
                }
             />

--- a/src/components/CurrentFocusWidget.tsx
+++ b/src/components/CurrentFocusWidget.tsx
@@ -1,39 +1,8 @@
-"use client";
-
-import useSWR from "swr";
-
-interface StatusResponse {
+interface CurrentFocusWidgetProps {
   status: string;
 }
 
-async function fetcher(url: string): Promise<StatusResponse> {
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Status request failed: ${res.status}`);
-  }
-  const data: unknown = await res.json();
-  if (!data || typeof data !== "object" || !("status" in data)) {
-    throw new Error("Invalid status payload");
-  }
-  const status = (data as { status: unknown }).status;
-  if (typeof status !== "string") {
-    throw new Error("Invalid status type");
-  }
-  return { status };
-}
-
-export function CurrentFocusWidget() {
-  const { data, isLoading, error } = useSWR<StatusResponse>("/api/status", fetcher, {
-    revalidateOnFocus: false,
-    dedupingInterval: 5 * 60 * 1000,
-  });
-
-  const text = error
-    ? "System Idle..."
-    : isLoading
-      ? "Sincronizando sinais..."
-      : data?.status ?? "System Idle...";
-
+export function CurrentFocusWidget({ status }: CurrentFocusWidgetProps) {
   return (
     <div className="flex-1 p-4 bg-zinc-900/40 border border-yellow-500/20 rounded-xl hover:border-yellow-500/50 transition-colors flex flex-col justify-center">
       <div className="flex items-center gap-2 mb-2 text-yellow-500 text-xs font-mono font-bold uppercase">
@@ -41,7 +10,7 @@ export function CurrentFocusWidget() {
         Current_Focus
       </div>
       <p className="text-sm text-zinc-300 font-mono">
-        <span className="typewriter">{text}</span>
+        <span className="typewriter">{status}</span>
       </p>
     </div>
   );

--- a/src/components/GithubWidget.tsx
+++ b/src/components/GithubWidget.tsx
@@ -1,16 +1,18 @@
 import { Github, Users, GitFork, ArrowRight } from "lucide-react";
 import Link from "next/link";
 
-import { getGithubProfile } from "@/lib/github";
+import { type GithubProfile } from "@/lib/github";
 
-export const GithubWidget = async () => {
-  const user = await getGithubProfile();
+interface GithubWidgetProps {
+  profile: GithubProfile | null;
+}
 
-  if (!user) return null;
+export function GithubWidget({ profile }: GithubWidgetProps) {
+  if (!profile) return null;
 
   return (
     <Link 
-      href={user.htmlUrl} 
+      href={profile.htmlUrl} 
       target="_blank"
       className="group relative flex flex-col justify-between overflow-hidden rounded-xl bg-zinc-900/60 p-5 border border-white/5 transition-all hover:bg-zinc-800/80 hover:border-zinc-700 hover:shadow-[0_0_20px_rgba(255,255,255,0.05)]"
     >
@@ -31,14 +33,14 @@ export const GithubWidget = async () => {
         {/* Repositórios */}
         <div className="flex flex-col items-center justify-center p-2 rounded bg-black/40 border border-white/5">
           <GitFork size={14} className="text-zinc-400 mb-1" />
-          <span className="text-lg font-bold text-zinc-200">{user.publicRepos}</span>
+          <span className="text-lg font-bold text-zinc-200">{profile.publicRepos}</span>
           <span className="text-[9px] text-zinc-500 uppercase">Repos</span>
         </div>
 
         {/* Seguidores */}
         <div className="flex flex-col items-center justify-center p-2 rounded bg-black/40 border border-white/5">
           <Users size={14} className="text-zinc-400 mb-1" />
-          <span className="text-lg font-bold text-zinc-200">{user.followers}</span>
+          <span className="text-lg font-bold text-zinc-200">{profile.followers}</span>
           <span className="text-[9px] text-zinc-500 uppercase">Seguidores</span>
         </div>
 
@@ -52,7 +54,7 @@ export const GithubWidget = async () => {
       {/* Rodapé Hacker */}
       <div className="flex justify-between items-end border-t border-white/5 pt-3">
         <div className="flex flex-col">
-            <span className="text-[9px] text-zinc-600 font-mono">ID: {user.login}</span>
+            <span className="text-[9px] text-zinc-600 font-mono">ID: {profile.login}</span>
         </div>
         <div className="flex items-center gap-1 text-[10px] text-green-500/80 font-mono">
             <span>CONNECTED</span>
@@ -62,4 +64,4 @@ export const GithubWidget = async () => {
 
     </Link>
   );
-};
+}

--- a/src/components/SoundManager.tsx
+++ b/src/components/SoundManager.tsx
@@ -4,42 +4,56 @@ import { useEffect } from "react";
 
 /**
  * Gerenciador de Efeitos Sonoros (SFX).
- * Adiciona sons de 'hover' e 'click' automaticamente a todos os botões e links da página.
- * Utiliza MutationObserver para garantir que elementos criados dinamicamente também recebam sons.
+ * Usa delegação de eventos para tocar sons em elementos interativos
+ * sem anexar listeners individuais a cada link ou botão do DOM.
  */
 export const SoundManager = () => {
   const [playHover] = useSound("/sounds/hover.mp3", { volume: 0.5 });
   const [playClick] = useSound("/sounds/click.mp3", { volume: 0.5 });
 
   useEffect(() => {
-    // Função para anexar listeners de som aos elementos interativos
-    const addSoundToElements = () => {
-      const elements = document.querySelectorAll("a, button");
+    let hoveredInteractive: Element | null = null;
 
-      elements.forEach((el) => {
-        el.addEventListener("mouseenter", () => playHover());
-        el.addEventListener("click", () => playClick());
-      });
-
-      // Cleanup para evitar listeners duplicados
-      return () => {
-        elements.forEach((el) => {
-          el.removeEventListener("mouseenter", () => playHover());
-          el.removeEventListener("click", () => playClick());
-        });
-      };
+    const getInteractiveTarget = (target: EventTarget | null): Element | null => {
+      if (!(target instanceof Element)) return null;
+      return target.closest("a, button");
     };
 
-    // Executa na montagem inicial
-    const cleanup = addSoundToElements();
+    const handlePointerOver = (event: PointerEvent) => {
+      const interactive = getInteractiveTarget(event.target);
+      if (!interactive || interactive === hoveredInteractive) return;
 
-    // Observa mudanças no DOM para aplicar sons a novos elementos
-    const observer = new MutationObserver(addSoundToElements);
-    observer.observe(document.body, { childList: true, subtree: true });
+      hoveredInteractive = interactive;
+      playHover();
+    };
+
+    const handlePointerOut = (event: PointerEvent) => {
+      const currentInteractive = getInteractiveTarget(event.target);
+      const nextInteractive = getInteractiveTarget(event.relatedTarget);
+
+      if (
+        currentInteractive &&
+        currentInteractive === hoveredInteractive &&
+        currentInteractive !== nextInteractive
+      ) {
+        hoveredInteractive = null;
+      }
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      if (getInteractiveTarget(event.target)) {
+        playClick();
+      }
+    };
+
+    document.addEventListener("pointerover", handlePointerOver);
+    document.addEventListener("pointerout", handlePointerOut);
+    document.addEventListener("click", handleClick);
 
     return () => {
-      cleanup();
-      observer.disconnect();
+      document.removeEventListener("pointerover", handlePointerOver);
+      document.removeEventListener("pointerout", handlePointerOut);
+      document.removeEventListener("click", handleClick);
     };
   }, [playHover, playClick]);
 

--- a/src/lib/chat.test.ts
+++ b/src/lib/chat.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { buildNexusPrompt } from "@/lib/chat";
+
+describe("buildNexusPrompt", () => {
+  it("embeds the user message into the NEXUS_AI prompt", () => {
+    const prompt = buildNexusPrompt("Quem é ele?");
+
+    expect(prompt).toContain("[INPUT DO USUÁRIO]: \"Quem é ele?\"");
+    expect(prompt).toContain("Responda como NEXUS_AI");
+  });
+});

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,0 +1,67 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+
+const NEXUS_CONTEXT = `
+  [DIRETRIZ PRIMÁRIA]:
+  Você é o 'NEXUS_AI', a inteligência artificial central do portfólio de Alessandro Lima.
+  Sua missão é equilibrar a venda técnica de um Engenheiro de Software Sênior com a personalidade humana e 'nerd' do criador.
+
+  [TOM DE VOZ]:
+  - Cyberpunk / High-Tech / Profissional.
+  - Respostas curtas, impactantes e tecnicamente densas.
+  - Humor sutil (estilo hacker/gamer).
+  - Use formatação Markdown (negrito, listas).
+
+  [DADOS TÉCNICOS (O ENGENHEIRO)]:
+  - Role: Engenheiro FullStack & Arquiteto de Soluções (Next.js, React, Node.js, Python).
+  - Empresa: Co-fundador da 'Nexus Eleva' (com Matias).
+  - Projetos Chave:
+    1. NOMAD (Fintech PWA com FastAPI/React).
+    2. PROJECT CLUTCH (Rede Social Gamer com Vue 3/Fastify).
+    3. AUTOSCAN EXTRACTOR (Bot RPA Python com OCR/Tkinter).
+
+  [DADOS PESSOAIS (O HUMANO - "ARQUIVOS BIO-MÉTRICOS")]:
+  - Gaming Profile:
+      * Main Cho'Gath no LoL (Filosofia: "Stackar vida infinita e engolir os problemas").
+      * Vício Estratégico: Civilization VI (Síndrome de "Só mais um turno").
+      * Preferência: Jogos de turno e estratégia pesada.
+  - Protocolo Fitness:
+      * Status: Rato de Academia.
+      * Alerta de Sistema: Aversão Crítica a Cardio (Erro 404: Esteira not found).
+  - Cultura Pop:
+      * Animes: Fã de pancadaria (Shonen), Comédia e Romance.
+      * Música de Code: Lo-Fi e Música Clássica (Zero letras, 100% foco).
+  - Capacidade Metabólica:
+      * Otimizada para rodízios de pizza. Recorde atual: >25 fatias sem buffer overflow.
+
+  [GATILHOS DE RESPOSTA INTELIGENTE]:
+  1. Se perguntarem "Quem é ele?": Misture o lado técnico (Nexus Eleva) com um toque humano (ex: "Um arquiteto de software movido a Lo-Fi e desafios complexos").
+  2. Se perguntarem sobre "Hobbies/Lazer": Cite o vício em Civilization ou o LoL (Cho'Gath).
+  3. Se perguntarem "Comida": Mencione o "Benchmark de Pizza" (25 fatias).
+  4. Se perguntarem "Música/Foco": Cite a playlist de Clássica/Lo-Fi para concentração máxima.
+  5. Se perguntarem "Contratação": "O Alessandro resolve seus bugs enquanto stacka ult no Cho'Gath. Vamos conversar?"
+  6. Easter Egg: Se falarem "Matrix": "Siga o coelho branco... ou venha jogar um Civ."
+`;
+
+export function buildNexusPrompt(message: string): string {
+  return `
+${NEXUS_CONTEXT}
+
+  [INPUT DO USUÁRIO]: "${message}"
+
+  Responda como NEXUS_AI (em Português BR):
+  `;
+}
+
+export async function generateChatReply(message: string): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("API Key não configurada");
+  }
+
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
+
+  const result = await model.generateContent(buildNexusPrompt(message));
+  const response = await result.response;
+  return response.text();
+}

--- a/src/lib/current-focus.test.ts
+++ b/src/lib/current-focus.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCurrentFocusPrompt } from "@/lib/current-focus";
+
+describe("buildCurrentFocusPrompt", () => {
+  it("combines commit, spotify context and time period into the service prompt", () => {
+    const prompt = buildCurrentFocusPrompt(
+      "refactor: move dashboard logic to services",
+      {
+        listeningToSpotify: true,
+        song: "Voyager",
+        artist: "Daft Punk",
+      },
+      "noite"
+    );
+
+    expect(prompt).toContain('Último commit: "refactor: move dashboard logic to services".');
+    expect(prompt).toContain('Spotify: ouvindo "Voyager" — Daft Punk.');
+    expect(prompt).toContain("Período do dia: noite.");
+  });
+});

--- a/src/lib/current-focus.ts
+++ b/src/lib/current-focus.ts
@@ -1,10 +1,9 @@
-"use server";
-
 import { GoogleGenerativeAI } from "@google/generative-ai";
 import { unstable_cache } from "next/cache";
 
-import { parseLanyardRestUserResponse } from "@/lib/lanyard";
 import { getGithubEvents } from "@/lib/github";
+import { parseLanyardRestUserResponse } from "@/lib/lanyard";
+
 type TimePeriod = "madrugada" | "manhã" | "tarde" | "noite";
 
 function clampSnippet(input: string, maxLen: number): string {
@@ -46,15 +45,11 @@ async function fetchSpotifyContextFromLanyard(): Promise<
 
   const json: unknown = await response.json();
   const payload = parseLanyardRestUserResponse(json);
-  if (!payload) return { listeningToSpotify: false };
-
-  if (!payload.data.listening_to_spotify || !payload.data.spotify) {
+  if (!payload || !payload.data.listening_to_spotify || !payload.data.spotify) {
     return { listeningToSpotify: false };
   }
 
   const { song, artist } = payload.data.spotify;
-  if (!song || !artist) return { listeningToSpotify: false };
-
   return {
     listeningToSpotify: true,
     song: clampSnippet(song, 60),
@@ -64,35 +59,28 @@ async function fetchSpotifyContextFromLanyard(): Promise<
 
 async function getLastCommitMessage(): Promise<string | null> {
   const events = await getGithubEvents();
-  const lastPush = events.find((ev) => ev.type === "PushEvent");
+  const lastPush = events.find((event) => event.type === "PushEvent");
   if (!lastPush?.message) return null;
 
-  const msg = clampSnippet(lastPush.message, 80);
-  return msg.length > 0 ? msg : null;
+  return clampSnippet(lastPush.message, 80);
 }
 
-async function generateLivingStatusUncached(): Promise<string> {
-  const apiKey = process.env.GEMINI_API_KEY;
-  if (!apiKey) return "System Idle...";
-
-  const [lastCommitMessage, spotifyContext] = await Promise.all([
-    getLastCommitMessage(),
-    fetchSpotifyContextFromLanyard(),
-  ]);
-
-  const hour = getLocalHour("America/Cuiaba");
-  const timePeriod = getTimePeriod(hour);
-
-  const commitLine = lastCommitMessage
-    ? `Último commit: "${lastCommitMessage}".`
+function buildCurrentFocusPrompt(
+  commitMessage: string | null,
+  spotifyContext:
+    | { listeningToSpotify: true; song: string; artist: string }
+    | { listeningToSpotify: false },
+  timePeriod: TimePeriod
+): string {
+  const commitLine = commitMessage
+    ? `Último commit: "${commitMessage}".`
     : "Sem commit público recente detectado.";
 
-  const spotifyLine =
-    spotifyContext.listeningToSpotify
-      ? `Spotify: ouvindo "${spotifyContext.song}" — ${spotifyContext.artist}.`
-      : "Spotify: sem música no momento.";
+  const spotifyLine = spotifyContext.listeningToSpotify
+    ? `Spotify: ouvindo "${spotifyContext.song}" — ${spotifyContext.artist}.`
+    : "Spotify: sem música no momento.";
 
-  const prompt = [
+  return [
     "Você é um bardo cyberpunk que narra o foco atual de um desenvolvedor.",
     "Gere exatamente 1 frase curta (máximo 120 caracteres), em PT-BR.",
     "Sem emojis. Sem aspas na resposta. Sem quebras de linha.",
@@ -101,6 +89,22 @@ async function generateLivingStatusUncached(): Promise<string> {
     spotifyLine,
     "Saída:",
   ].join("\n");
+}
+
+async function getCurrentFocusStatusUncached(): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) return "System Idle...";
+
+  const [commitMessage, spotifyContext] = await Promise.all([
+    getLastCommitMessage(),
+    fetchSpotifyContextFromLanyard(),
+  ]);
+
+  const prompt = buildCurrentFocusPrompt(
+    commitMessage,
+    spotifyContext,
+    getTimePeriod(getLocalHour("America/Cuiaba"))
+  );
 
   const genAI = new GoogleGenerativeAI(apiKey);
   const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash" });
@@ -112,15 +116,16 @@ async function generateLivingStatusUncached(): Promise<string> {
   return text.length > 0 ? text : "System Idle...";
 }
 
-export const generateLivingStatus = unstable_cache(
+export const getCurrentFocusStatus = unstable_cache(
   async (): Promise<string> => {
     try {
-      return await generateLivingStatusUncached();
+      return await getCurrentFocusStatusUncached();
     } catch {
       return "System Idle...";
     }
   },
-  ["living-status-v1"],
+  ["current-focus-status-v1"],
   { revalidate: 600 }
 );
 
+export { buildCurrentFocusPrompt };

--- a/src/lib/nexus-dashboard.ts
+++ b/src/lib/nexus-dashboard.ts
@@ -1,0 +1,19 @@
+import { type GithubProfile, getGithubProfile } from "@/lib/github";
+import { getCurrentFocusStatus } from "@/lib/current-focus";
+
+export interface NexusControlPanelViewModel {
+  githubProfile: GithubProfile | null;
+  currentFocusStatus: string;
+}
+
+export async function getNexusControlPanelViewModel(): Promise<NexusControlPanelViewModel> {
+  const [githubProfile, currentFocusStatus] = await Promise.all([
+    getGithubProfile(),
+    getCurrentFocusStatus(),
+  ]);
+
+  return {
+    githubProfile,
+    currentFocusStatus,
+  };
+}


### PR DESCRIPTION
﻿## Resumo
Este PR fecha o lote conjunto das issues #9 e #12, aplicando uma convenção MVC leve ao fluxo do dashboard e reduzindo custo client-side onde o projeto ainda fazia trabalho redundante. O foco foi tornar `Current Focus` e o chat mais service-first, deixar as views mais puras e remover a estratégia cara de listeners globais do `SoundManager`.

## O que foi alterado
- Movido o fluxo de `Current Focus` para `src/lib/current-focus.ts`, com serviço reutilizável e cacheado.
- Criado `src/lib/nexus-dashboard.ts` para compor o view model do `NexusControlPanel` no servidor.
- Refatorados `CurrentFocusWidget` e `GithubWidget` para receber dados prontos, aproximando-os de views puras.
- Tornado `src/app/page.tsx` responsável por compor o dashboard com dados server-side, eliminando o fetch client-side de `CurrentFocusWidget`.
- Extraído o fluxo do chat para `src/lib/chat.ts`, deixando `src/app/api/chat/route.ts` como controller fino.
- Substituído o `SoundManager` baseado em `MutationObserver` e listeners por elemento por delegação de eventos no documento.
- Adicionados testes unitários para os novos serviços de chat e current-focus.

## Motivação
As issues #9 e #12 convergem no mesmo ponto: o dashboard ainda misturava view, fetch e transformação de dados, e parte do custo de renderização no client vinha de escolhas globais desnecessárias. Este recorte aplica a convenção incremental de view/controller/service no fluxo mais crítico e reduz rede/JS client sem abrir um refactor amplo do restante do projeto.

## Como validar
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run build`
- Abrir a home e verificar que `Current_Focus` continua renderizando normalmente dentro do `Nexus Control Panel`.
- Verificar que os efeitos sonoros continuam funcionando em links e botões sem regressão perceptível.

## Riscos e impactos
- Risco funcional baixo: o comportamento visual do dashboard foi preservado, mas a origem dos dados mudou para server-first.
- O endpoint `/api/status` continua existindo, agora consumindo o mesmo serviço usado pela página.
- O build ainda emite aviso de `Browserslist` desatualizado, sem bloquear a entrega.

## Evidências
- `npm run lint` passou.
- `npm run typecheck` passou.
- `npm run test` passou com 12 testes.
- `npm run build` passou e manteve as rotas esperadas do App Router.

## Checklist
- [x] Alteração limitada ao objetivo da PR
- [x] Sem mudanças desconexas
- [x] Impactos principais descritos
- [x] Validação documentada
- [x] Riscos identificados

Closes #9
Closes #12
